### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/flask_app.py
+++ b/flask_app.py
@@ -4,7 +4,7 @@ import csv
 import os
 import io
 from werkzeug.utils import secure_filename
-from fuzzywuzzy import process
+from rapidfuzz import process
 from data_loading import get_ingredient_score, get_candies, get_ingredients, get_good_candies, get_bad_candies
 import random
 
@@ -61,15 +61,10 @@ def detect_ingredients(client, path):
 
     ##### find the start and the end #######
     # find the ingredients mark.
-    (val, ratio) = process.extractOne('ingredient', words)
+    result = process.extractOne('ingredient', words, score_cutoff=90)
 
-    if ratio > 90:
-        ingredient_mark_found = True
-    else:
-        ingredient_mark_found = False
-
-    if ingredient_mark_found:
-        ingredient_idx = words.index(val)
+    if result:
+        ingredient_idx = words.index(result[0])
         str_ingredients = ' '.join(words[ingredient_idx + 1:])
     else:
         str_ingredients = ' '.join(words)

--- a/get_candy_scores.py
+++ b/get_candy_scores.py
@@ -1,6 +1,6 @@
 # read all the ingredient lists from csv
 import csv
-from fuzzywuzzy import process
+from rapidfuzz import process
 from pprint import pprint
 
 def get_candy_ingredients():
@@ -43,10 +43,9 @@ def calculate_average_score(new_ingredient_list, score_dict):
     for ingredient in new_ingredient_list:
         ingredient = ingredient.lower()
 
-        found_ingredients, ratio = process.extractOne(ingredient, known_ingredients)
-
-        if ratio > 80:
-            ingredient_score_str = score_dict[found_ingredients]
+        result = process.extractOne(ingredient, known_ingredients, score_cutoff=80)
+        if result:
+            ingredient_score_str = score_dict[result[0]]
             ingredient_score = float(ingredient_score_str)
             scores.append(ingredient_score)
         else:

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -6,6 +6,6 @@ google-auth-httplib2==0.0.3
 google-cloud-vision==0.41.0
 googleapis-common-protos==1.51.0
 ipython==4.1.2
-fuzzywuzzy==0.18.0
+rapidfuzz==0.3.0
 grpcio-tools==1.27.2
 grpcio==1.27.2


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is a lot faster than FuzzyWuzzy